### PR TITLE
perf: 추첨 및 투표 성능 최적화

### DIFF
--- a/app/(main)/donation/_views/Running.tsx
+++ b/app/(main)/donation/_views/Running.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import type { TimeType, ViewerType, VoteType } from "@/lib/types";
 import MainButton from "@/app/_components/Main/MainButton";
 import TimeElapsed from "@/app/_components/Vote/TimeElapsed";
@@ -43,45 +49,55 @@ export default function Running({
   const { channel } = useGlobalOptionStore();
   const [hidden, setHidden] = useState<boolean>(false);
 
+  // 데이터를 버퍼링하기 위한 ref
+  const voteSet = useRef(new Set<string>());
+  const voteBuffer = useRef<VoteType[]>([...vote]);
+  const bufferTimeout = useRef<NodeJS.Timeout>();
+
   function handleOnDonation(
     viewer: ViewerType,
     message: string,
     price: number
   ) {
+    if (!voteSet.current || !voteBuffer.current) return;
     if (doneConfig.price > price) return;
 
     const onlyNumber = extractVoteNumber(message);
-    if (!onlyNumber) return;
+    if (!onlyNumber || onlyNumber > vote.length) return;
 
     const number = onlyNumber - 1;
 
-    setVote((prev) => {
-      const thisVote = prev[number];
-      if (!thisVote) return prev;
-
-      //복수투표가 아닐 경우 (기존 투표를 지움)
-      if (!doneConfig.plural) {
-        const newVote = [...prev].map((item) => ({
+    //복수 투표가 아닐 경우 해당 사용자의 전 투표 기록을 삭제
+    if (!doneConfig.plural) {
+      if (voteSet.current.has(viewer.userIdHash)) {
+        voteBuffer.current = [...voteBuffer.current].map((item) => ({
           ...item,
           viewers: item.viewers.filter(
             (viewersItem) => viewersItem.userIdHash !== viewer.userIdHash
           ),
         }));
+      } else voteSet.current.add(viewer.userIdHash);
+    }
 
-        newVote[number].viewers.push(viewer);
-        return newVote;
-      }
+    let count = 1;
+    //복수 투표일 경우 금액에 따른 추가 횟수 증가
+    if (doneConfig.plural) {
+      count = Math.floor(price / doneConfig.price);
+    }
 
-      //복수투표일 경우 (기존 투표를 지우지 않음)
-      const newVote = [...prev];
-      const count = Math.floor(price / doneConfig.price);
+    for (let i = 0; i < count; i++) {
+      //버퍼에 데이터 넣기
+      voteBuffer.current[number].viewers.push(viewer);
+    }
 
-      for (let i = 0; i < count; i++) {
-        newVote[number].viewers.push(viewer);
-      }
+    // 버퍼링된 데이터를 일정 주기로 한번에 업데이트
+    if (!bufferTimeout.current) {
+      setVote([...voteBuffer.current]);
 
-      return newVote;
-    });
+      bufferTimeout.current = setTimeout(() => {
+        bufferTimeout.current = undefined;
+      }, 500); // 500ms마다 업데이트
+    }
   }
 
   useEffect(() => {

--- a/app/(main)/viewer/_views/Running.tsx
+++ b/app/(main)/viewer/_views/Running.tsx
@@ -38,7 +38,7 @@ export default function Running({
   const bufferTimeout = useRef<NodeJS.Timeout>();
 
   function handleOnChat(viewer: ViewerType) {
-    if (!viewerSet.current) return;
+    if (!viewerSet.current || !viewerBuffer.current) return;
 
     if (!viewerSet.current.has(viewer.userIdHash)) {
       viewerSet.current.add(viewer.userIdHash);

--- a/app/(main)/viewer/_views/Running.tsx
+++ b/app/(main)/viewer/_views/Running.tsx
@@ -3,7 +3,13 @@
 import MainButton from "@/app/_components/Main/MainButton";
 import { Container } from "./index.styled";
 import { ViewersConfigType, ViewerType } from "@/lib/types";
-import { useState, useEffect, type Dispatch, type SetStateAction } from "react";
+import {
+  useState,
+  useEffect,
+  type Dispatch,
+  type SetStateAction,
+  useRef,
+} from "react";
 import Config from "../../../_components/Viewer/Config";
 import Viewers from "../../../_components/Viewer/Viewers";
 import { useGlobalOptionStore } from "@/lib/zustand";
@@ -26,13 +32,27 @@ export default function Running({
 }) {
   const { channel } = useGlobalOptionStore();
 
-  function handleOnChat(viewer: ViewerType) {
-    setViewers((prev) => {
-      const find = prev.find((item) => item.userIdHash === viewer.userIdHash);
-      if (find) return prev;
+  // 데이터를 버퍼링하기 위한 ref
+  const viewerSet = useRef(new Set<string>());
+  const viewerBuffer = useRef<ViewerType[]>([]);
+  const bufferTimeout = useRef<NodeJS.Timeout>();
 
-      return [...prev, viewer];
-    });
+  function handleOnChat(viewer: ViewerType) {
+    if (!viewerSet.current) return;
+
+    if (!viewerSet.current.has(viewer.userIdHash)) {
+      viewerSet.current.add(viewer.userIdHash);
+      viewerBuffer.current.push(viewer);
+
+      // 버퍼링된 데이터를 일정 주기로 한번에 업데이트
+      if (!bufferTimeout.current) {
+        setViewers([...viewerBuffer.current]);
+
+        bufferTimeout.current = setTimeout(() => {
+          bufferTimeout.current = undefined;
+        }, 500); // 500ms마다 업데이트
+      }
+    }
   }
 
   useEffect(() => {

--- a/app/(main)/vote/_views/Running.tsx
+++ b/app/(main)/vote/_views/Running.tsx
@@ -91,7 +91,8 @@ export default function Running({
     if (!voteSet.current || !voteBuffer.current) return;
 
     const onlyNumber = extractVoteNumber(message);
-    if (!onlyNumber) return;
+    if (!onlyNumber || onlyNumber > vote.length) return;
+
     const number = onlyNumber - 1;
 
     //이미 투표한 적 있는 사용자라면


### PR DESCRIPTION
다음과 같은 변경사항으로 초당 1000회 이상의 대용량 트래픽 발생 시 성능 개선을 기대할 수 있습니다.

1. 상태 관리 매커니즘 변경
- 기존에는 매 요청시마다 state를 변경하여, 매 요청마다 재랜더링하였음
- 버퍼를 만들어 버퍼에 우선 저장 후 500ms에 한번씩 재렌더링하도록 변경
2. 중복제거 매커니즘 변경
- Array.find와 Array.filter는 모든 항목을 순회해야 하므로 O(n), Set은 O(1)의 시간이 소요됨
- Set에 투표한 적 있는 시청자를 저장해 해당하는 경우에만 중복제거하거나 추첨에 포함시키지 않음
